### PR TITLE
include MAJOR version in SONAME in build.rs

### DIFF
--- a/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c-1.5.0/0004-include-MAJOR-version-in-SONAME.patch
+++ b/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c-1.5.0/0004-include-MAJOR-version-in-SONAME.patch
@@ -1,0 +1,23 @@
+From 1895d8d4075c6565ec2ff7108a008827243a1299 Mon Sep 17 00:00:00 2001
+From: Georg Schmalhofer <georg.schmalhofer@gmail.com>
+Date: Sun, 28 Sep 2025 08:21:13 +0200
+Subject: [PATCH] include MAJOR version in SONAME
+
+Signed-off-by: Georg Schmalhofer <georg.schmalhofer@gmail.com>
+---
+ build.rs | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/build.rs b/build.rs
+index f2099a0b..9905aee1 100644
+--- a/build.rs
++++ b/build.rs
+@@ -57,7 +57,7 @@ fn main() {
+     if std::env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok("linux") {
+         let name = std::env::var("CARGO_PKG_NAME").unwrap();
+         // Create the shared library name by removing hyphens from the pkg_name
+-        let soname = format!("lib{}.so", name.replace('-', ""));
++        let soname = format!("lib{}.so.1", name.replace('-', ""));
+         println!("cargo:rustc-cdylib-link-arg=-Wl,-soname,{}", soname);
+     }
+ }

--- a/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c_1.5.0.bb
+++ b/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c_1.5.0.bb
@@ -1,6 +1,9 @@
 require ${BPN}.inc
 require ${BP}-crates.inc
 
-SRC_URI += "file://0003-use-frozen-in-opaque_types_generator.rs.patch"
+SRC_URI += " \
+file://0003-use-frozen-in-opaque_types_generator.rs.patch \
+file://0004-include-MAJOR-version-in-SONAME.patch \
+"
 
 SRCREV = "f5d5a90d720d96d50f13b2718c4e1acd6714682a"


### PR DESCRIPTION
The shared library was being built without a versioned SONAME, causing executables to link against the generic library name, which is then not present in the system library path.