### PR TITLE
license syntax fixes

### DIFF
--- a/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c.inc
+++ b/meta-zenoh/recipes-connectivity/zenoh-c/zenoh-c.inc
@@ -1,7 +1,7 @@
 SUMMARY = "The Zenoh C API"
 DESCRIPTION = "C binding based on the main Zenoh implementation written in Rust"
 HOMEPAGE = "http://zenoh.io"
-LICENSE = "EPL-2.0 | Apache-2.0"
+LICENSE = "Apache-2.0 OR EPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=530d837aca648e45704db71dedff39c4"
 
 inherit cmake cargo pkgconfig rust-msrv

--- a/meta-zenoh/recipes-connectivity/zenoh-cpp/zenoh-cpp.inc
+++ b/meta-zenoh/recipes-connectivity/zenoh-cpp/zenoh-cpp.inc
@@ -1,6 +1,6 @@
 SUMMARY = "C++ API for Zenoh"
 HOMEPAGE = "http://zenoh.io"
-LICENSE = "EPL-2.0 | Apache-2.0"
+LICENSE = "Apache-2.0 OR EPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=530d837aca648e45704db71dedff39c4"
 
 inherit cmake

--- a/meta-zenoh/recipes-connectivity/zenoh-pico/zenoh-pico.inc
+++ b/meta-zenoh/recipes-connectivity/zenoh-pico/zenoh-pico.inc
@@ -2,7 +2,7 @@ SUMMARY = "Eclipse zenoh for pico devices"
 DESCRIPTION = "zenoh-pico is the Eclipse zenoh implementation that targets constrained devices, offering a native C API. \
 It is fully compatible with its main Rust Zenoh implementation, providing a lightweight implementation of most functionalities."
 HOMEPAGE = "http://zenoh.io"
-LICENSE = "EPL-2.0 | Apache-2.0"
+LICENSE = "Apache-2.0 OR EPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d296d6e2747ca8f5caae4b30fdad6b21"
 
 inherit cmake

--- a/meta-zenoh/recipes-connectivity/zenoh/zenoh.inc
+++ b/meta-zenoh/recipes-connectivity/zenoh/zenoh.inc
@@ -1,6 +1,6 @@
 SUMMARY = "The zenoh router"
 HOMEPAGE = "http://zenoh.io"
-LICENSE = "EPL-2.0 | Apache-2.0"
+LICENSE = "Apache-2.0 OR EPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=530d837aca648e45704db71dedff39c4"
 
 SRC_URI = "git://github.com/eclipse-zenoh/zenoh.git;protocol=https;nobranch=1"

--- a/meta-zenoh/recipes-devtools/python3-eclipse-zenoh/python3-eclipse-zenoh.inc
+++ b/meta-zenoh/recipes-devtools/python3-eclipse-zenoh/python3-eclipse-zenoh.inc
@@ -1,7 +1,7 @@
 SUMMARY = "Python API for zenoh"
 DESCRIPTION = "This repository provides a Python binding based on the main Zenoh implementation written in Rust."
 HOMEPAGE = "https://zenoh.io"
-LICENSE = "EPL-2.0 | Apache-2.0"
+LICENSE = "Apache-2.0 OR EPL-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=530d837aca648e45704db71dedff39c4"
 
 inherit python_maturin rust-msrv


### PR DESCRIPTION
Current master of openembedded-core has some changes about the LICENSE string.
This if fixing it.

WARNING: .../meta-zenoh/meta-zenoh/recipes-connectivity/zenoh/zenoh_1.6.2.bb: zenoh-native: LICENSE is using an old syntax and should be upgraded to: "Apache-2.0 OR EPL-2.0"


